### PR TITLE
단일 카드 선택 기능 추가

### DIFF
--- a/app/src/main/java/com/android/code/ui/search/SearchAdapterProperty.kt
+++ b/app/src/main/java/com/android/code/ui/search/SearchAdapterProperty.kt
@@ -5,6 +5,7 @@ import com.bumptech.glide.RequestManager
 
 interface SearchAdapterProperty {
     val requestManager: RequestManager
+    val searchedData: LiveData<SearchBaseData>
     val searchedText: LiveData<String>
     fun search(text: String)
     fun removeRecentSearch(text: String)

--- a/app/src/main/java/com/android/code/ui/search/SearchBaseViewModel.kt
+++ b/app/src/main/java/com/android/code/ui/search/SearchBaseViewModel.kt
@@ -31,6 +31,10 @@ abstract class SearchBaseViewModel(open val marvelRepository: MarvelRepository) 
     override val clickData: LiveData<SearchData>
         get() = _clickData
 
+    private val _searchedData = SafetyMutableLiveData<SearchBaseData>()
+    override val searchedData: LiveData<SearchBaseData>
+        get() = _searchedData
+
     private val _searchedText = SafetyMutableLiveData<String>()
     override val searchedText: LiveData<String>
         get() = _searchedText
@@ -172,6 +176,9 @@ abstract class SearchBaseViewModel(open val marvelRepository: MarvelRepository) 
 
     override fun clickData(searchData: SearchData) {
         _clickData.setValueSafety(searchData)
+        if (searchData is SearchBaseData) {
+            _searchedData.setValueSafety(searchData)
+        }
     }
 }
 
@@ -187,5 +194,6 @@ interface SearchViewModelOutput {
     val responseData: LiveData<Pair<List<SearchData>, Boolean>>
     val recentSearchList: LiveData<List<String>>
     val clickData: LiveData<SearchData>
+    val searchedData: LiveData<SearchBaseData>
     val searchedText: LiveData<String>
 }

--- a/app/src/main/java/com/android/code/ui/search/SearchGridFragment.kt
+++ b/app/src/main/java/com/android/code/ui/search/SearchGridFragment.kt
@@ -28,6 +28,8 @@ class SearchGridFragment : BaseFragment<FragmentSearchGridBinding>(), OnRefreshL
         SearchAdapter(object : SearchAdapterProperty {
             override val requestManager: RequestManager
                 get() = this@SearchGridFragment.requestManager
+            override val searchedData: LiveData<SearchBaseData>
+                get() = viewModel.searchedData
             override val searchedText: LiveData<String>
                 get() = viewModel.searchedText
 

--- a/app/src/main/java/com/android/code/ui/search/SearchStaggeredFragment.kt
+++ b/app/src/main/java/com/android/code/ui/search/SearchStaggeredFragment.kt
@@ -28,6 +28,8 @@ class SearchStaggeredFragment : BaseFragment<FragmentSearchStaggeredBinding>(), 
         SearchAdapter(object : SearchAdapterProperty {
             override val requestManager: RequestManager
                 get() = this@SearchStaggeredFragment.requestManager
+            override val searchedData: LiveData<SearchBaseData>
+                get() = viewModel.searchedData
             override val searchedText: LiveData<String>
                 get() = viewModel.searchedText
 

--- a/app/src/main/res/layout/holder_search_data.xml
+++ b/app/src/main/res/layout/holder_search_data.xml
@@ -13,6 +13,10 @@
             name="data"
             type="com.android.code.ui.search.SearchBaseData" />
 
+        <variable
+            name="isSelected"
+            type="Boolean" />
+
         <import type="android.text.TextUtils" />
 
         <import type="android.view.View" />
@@ -24,7 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         android:onClick="@{() -> property.clickData(data)}"
-        app:cardBackgroundColor="@color/white"
+        app:cardBackgroundColor="@{isSelected ? @color/color_f5f5f5 : @color/white}"
         app:cardCornerRadius="10dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
### PR 간단하게 설명 해주세요.

- 단일 카드 선택 기능 추가
- 스크롤 이동시에도 카드가 선택되어야 한다.
- 다른 카드를 누를시 그전의 카드는 원복 되어야 한다.



### PR 에 포함 될 유틸 중 유용하게 쓰일 상황 있다면 말해주세요.

- ViewDetectable interface 를 이용하여 attach detach 와 연결 시켜 liveData 를 실시간으로 연결 ( holder 에는 라이프 사이클이 없기 때문에 )
- 필요하다면 ViewHolder 에 lifeCycleOwner 주입시켜 라이프사이클 만들어줌


### 테스트 진행 여부

- [x] 개발 서버 테스트 완료
- [x] 실서버 테스트 완료
